### PR TITLE
handle proxy option in Client constructor + change connections callback signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /node_modules
+.idea/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Authrep is a 'one-shot' operation to authorize an application and report the ass
 ```javascript
 var Client = require('3scale').Client;
 
-client = new Client("your provider key");
+client = new Client("your provider key",["3Scale URL(default : su1.3scale.net)"],["proxy URL"]);
 
 client.authrep({"app_id": "your application id", "app_key": "your application key", "usage": { "hits": 1 } }, function(response){
   sys.log(sys.inspect(response));
@@ -52,8 +52,9 @@ var Client = require('3scale').Client;
 
 client = new Client("your provider key");
 
-client.authorize({"app_id": "your application id", "app_key": "your application key"}, function(response){
-  if (response.is_success()) {
+client.authorize({"app_id": "your application id", "app_key": "your application key"}, function(error, response){
+  if(error) {console.err(error);}
+  else if (response.is_success()) {
     var trans = [{"app_id": "your application id", "usage": {"hits": 3}}];
     client.report(trans, function (response) {
       console.log(response);
@@ -87,8 +88,9 @@ var Client = require('3scale').Client;
 
 client = new Client("your provider key");
 
-client.oauth_authorize({"app_id": "your application id"}, function(response){
-  if (response.is_success()) {
+client.oauth_authorize({"app_id": "your application id"}, function(error, response){
+  if(error) {console.err(error);}
+  else if (response.is_success()) {
     var trans = [{"app_id": "your application id", "usage": {"hits": 3}}];
     client.report(trans, function (response) {
       console.log(response);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "libxmljs": "*",
-    "qs": "*"
+    "qs": "*",
+    "https-proxy-agent": "*"
   },
   "devDependencies": {
     "coffee-script": "1.x",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -5,6 +5,8 @@ VERSION = require('../package.json').version
 
 Response = require './response'
 AuthorizeResponse = require './authorize_response'
+HttpsProxyAgent = require 'https-proxy-agent'
+agent = null
 
 ###
   3Scale client API
@@ -19,11 +21,14 @@ AuthorizeResponse = require './authorize_response'
 module.exports = class Client
   DEFAULT_HEADERS: { "X-3scale-User-Agent": "plugin-node-v#{VERSION}" }
 
-  constructor: (provider_key, default_host = "su1.3scale.net") ->
+  constructor: (provider_key, default_host = "su1.3scale.net", proxyUrl) ->
     unless provider_key?
       throw new Error("missing provider_key")
     @provider_key = provider_key
     @host = default_host
+    if proxyUrl
+      agent = new HttpsProxyAgent(proxyUrl);
+
 
   ###
     Authorize a application
@@ -62,6 +67,8 @@ module.exports = class Client
       path:   url + query
       method: 'GET'
       headers: @DEFAULT_HEADERS
+    if agent
+      req_opts.agent = agent
 
     request = https.request req_opts, (response) ->
       response.setEncoding 'utf8'
@@ -71,11 +78,13 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback null, _self._build_success_authorize_response xml
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback null, _self._build_error_response xml
         else
           throw "[Client::authorize] Server Error Code: #{response.statusCode}"
+    request.on 'error', (err) ->
+      callback err
     request.end()
 
   ###
@@ -110,6 +119,8 @@ module.exports = class Client
       path:   url + query
       method: 'GET'
       headers: @DEFAULT_HEADERS
+    if agent
+      req_opts.agent = agent
 
     request = https.request req_opts, (response) ->
       response.setEncoding 'utf8'
@@ -119,11 +130,13 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback null, _self._build_success_authorize_response xml
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback null, _self._build_error_response xml
         else
           throw "[Client::oauth_authorize] Server Error Code: #{response.statusCode}"
+    request.on 'error', (err) ->
+      callback err
     request.end()
 
   ###
@@ -159,6 +172,8 @@ module.exports = class Client
       path:   url + query
       method: 'GET'
       headers: @DEFAULT_HEADERS
+    if agent
+      req_opts.agent = agent
 
     request = https.request req_opts, (response) ->
       response.setEncoding 'utf8'
@@ -168,11 +183,13 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback null, _self._build_success_authorize_response xml
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback null, _self._build_error_response xml
         else
           throw "[Client::authorize_with_user_key] Server Error Code: #{response.statusCode}"
+    request.on 'error', (err) ->
+      callback err
     request.end()
 
   ###
@@ -207,6 +224,8 @@ module.exports = class Client
       path:   url + query
       method: 'GET'
       headers: @DEFAULT_HEADERS
+    if agent
+      req_opts.agent = agent
 
     request = https.request req_opts, (response) ->
       response.setEncoding 'utf8'
@@ -216,11 +235,13 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback null, _self._build_success_authorize_response xml
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback null, _self._build_error_response xml
         else
           throw "[Client::authrep] Server Error Code: #{response.statusCode}"
+    request.on 'error', (err) ->
+      callback err
     request.end()
 
   ###
@@ -242,6 +263,8 @@ module.exports = class Client
       path:   url + query
       method: 'GET'
       headers: @DEFAULT_HEADERS
+    if agent
+      req_opts.agent = agent
 
     request = https.request req_opts, (response) ->
       response.setEncoding 'utf8'
@@ -251,11 +274,13 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback null, _self._build_success_authorize_response xml
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback null, _self._build_error_response xml
         else
           throw "[Client::authrep_with_user_key] Server Error Code: #{response.statusCode}"
+    request.on 'error', (err) ->
+      callback err
     request.end()
 
   ###
@@ -310,6 +335,8 @@ module.exports = class Client
         "host": @host
         "Content-Type": "application/x-www-form-urlencoded"
         "Content-Length": query.length
+    if agent
+      req_opts.agent = agent
 
     req_opts.headers[key] = value for key, value of @DEFAULT_HEADERS
 


### PR DESCRIPTION
Hello,
I suggest you this PR, to handle Client.prototype.*authorize connections errors and add the possibility to pass a proxy url in the Client constructor.

Regards,
Camille 

PS : I wanted to update the tests but I cannot launch them, I got only provider_key and user_key

