### PR TITLE
Add tests for usage reports and use Mocha for simpler tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache: npm
 node_js:
 - "0.8"
 - "0.10"
+- "0.12"
+- "4"
 before_install:
   - npm install -g npm@~1.4.6
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: node_js
 sudo: false
 cache: npm
 node_js:
-- "0.8"
 - "0.10"
 - "0.12"
 - "4"
 before_install:
-  - npm install -g npm@~1.4.6
+  - npm install -g npm@2
 env:
   global:
   - TEST_3SCALE_APP_ID=4d4b20b9

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ before_install:
   - npm install -g npm@2
 env:
   global:
-  - TEST_3SCALE_APP_ID=4d4b20b9
-  - TEST_3SCALE_APP_KEY=ecce202ecc2eb8dc7a499c34a34d5987
-  - secure: B/3oWYZZttrXVM5IFn2evSuWMOQqEOOMol3nEQ2vEDGQ6rdGjpYLFDO/qMDPA8Af6Vt72lOFKkgzivuBp8nSd4S1YRTazilMle4zCJiJxzPs69kRDVXf/Mn8Qr/YrmgVzhblvdNqbKxTGrYyvDziPkliQKtIhqyILm3d6+CqmYw=
+    - CXX=g++-4.8
+    - TEST_3SCALE_APP_ID=4d4b20b9
+    - TEST_3SCALE_APP_KEY=ecce202ecc2eb8dc7a499c34a34d5987
+    - secure: B/3oWYZZttrXVM5IFn2evSuWMOQqEOOMol3nEQ2vEDGQ6rdGjpYLFDO/qMDPA8Af6Vt72lOFKkgzivuBp8nSd4S1YRTazilMle4zCJiJxzPs69kRDVXf/Mn8Qr/YrmgVzhblvdNqbKxTGrYyvDziPkliQKtIhqyILm3d6+CqmYw=
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The module is delivered through the package manager npm, so that the installatio
 
 * libxml2 library
 
-Starting at version 0.5.0, this plugin requires using **Node.js versions 0.8.x or higher**. Node.js 0.6.x is no longer supported due to incompatibilities that break the tests.
+Starting at version 0.6.0, this plugin requires using **Node.js versions 0.10.x or higher**.
 
 
 ## Synopsis

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "nock": "^3.3.2"
   },
   "engines": {
-    "node": ">=0.8.0",
-    "npm": ">=1.4.0"
+    "node": ">=0.10.0",
+    "npm": ">=2.0.0"
   },
   "optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3scale",
   "description": "Client for 3Scale Networks API",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "homepage": "http://www.3scale.net",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "scripts": {
     "prepublish": "coffee --bare -o lib -c src",
-    "test": "vows test/* --spec"
+    "test": "mocha --compilers coffee:coffee-script/register test/*"
   },
   "directories": {
     "lib": "./lib"
@@ -38,9 +38,9 @@
     "qs": "*"
   },
   "devDependencies": {
-    "coffee-script": "1.x",
-    "nock": "0.46.0",
-    "vows": "0.8.x"
+    "coffee-script": "^1.10.0",
+    "mocha": "^2.3.4",
+    "nock": "^3.3.2"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "libxmljs": "*",
-    "qs": "*"
+    "qs": "^5.2.0"
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -350,8 +350,8 @@ module.exports = class Client
           report =
             period: usage_report.attr('period').value()
             metric: usage_report.attr('metric').value()
-            period_start: if @period is not 'eternity' then usage_report.get('period_start').text()
-            period_end: if @period is not 'eternity' then usage_report.get('period_end').text()
+            period_start: if @period isnt 'eternity' then usage_report.get('period_start').text()
+            period_end: if @period isnt 'eternity' then usage_report.get('period_end').text()
             current_value: usage_report.get('current_value').text()
             max_value: usage_report.get('max_value').text()
           response.add_usage_reports report

--- a/test/authorize_response_test.coffee
+++ b/test/authorize_response_test.coffee
@@ -1,27 +1,23 @@
-vows = require 'vows'
 assert = require 'assert'
 
 AuthorizeResponse = require('../src/authorize_response')
 
-usage_report_options = 
-	metric: 'hits'
-	period: 'month'
-	current_value: 17344
-	max_value: 20000
-	period_start: '2010-08-01 00:00:00 +00:00'
-	period_end: '2010-09-01 00:00:00 +00:00'
+usage_report_options =
+  metric: 'hits'
+  period: 'month'
+  current_value: 17344
+  max_value: 20000
+  period_start: '2010-08-01 00:00:00 +00:00'
+  period_end: '2010-09-01 00:00:00 +00:00'
 
-vows
-  .describe("Basic test for the 3Scale::AuthorizeResponse")
-  .addBatch
-    'A authorize_response Should':
-      topic: -> new AuthorizeResponse()
-      'have a add_usage_report method': (authorize_response) ->
-        assert.isFunction authorize_response.add_usage_reports
+describe 'Basic test for the 3Scale::AuthorizeResponse', ->
+  describe 'an authorize_response', ->
+    it 'should have a add_usage_report method', ->
+      authorize_response = new AuthorizeResponse()
+      assert.equal typeof authorize_response.add_usage_reports, 'function'
 
-      'can push a new UsageReport': (authorize_response) ->
-        assert.lengthOf authorize_response.usage_reports, 0
-        authorize_response.add_usage_reports usage_report_options
-        assert.lengthOf authorize_response.usage_reports, 1
-		
-  .export(module)
+    it 'should be able to push a new UsageReport', ->
+      authorize_response = new AuthorizeResponse()
+      assert.equal authorize_response.usage_reports.length, 0
+      authorize_response.add_usage_reports usage_report_options
+      assert.equal authorize_response.usage_reports.length, 1

--- a/test/response_test.coffee
+++ b/test/response_test.coffee
@@ -1,44 +1,46 @@
-vows = require 'vows'
 assert = require 'assert'
 
-# Object to testing
 Response = require('../src/response')
 
-vows
-  .describe("Basic test for the 3Scale::Response")
-  .addBatch
-    'A response Should':
-      topic: -> new Response()
-      'have a success method': (response) ->
-        assert.isFunction response.success
+describe 'Basic test for the 3Scale::Response', ->
+  describe 'a response', ->
+    it 'should have a success method', ->
+      response = new Response()
+      assert.equal typeof response.success, 'function'
 
-      'have a code & message null after a success': (response) ->
-        response.success()
-        assert.isNull(response.error_code)
-        assert.isNull(response.error_message)
+    it 'should have a code & message null after a success', ->
+      response = new Response()
+      response.success()
+      assert.equal response.error_code, null
+      assert.equal response.error_message, null
 
-      'have a error method': (response) ->
-        assert.isFunction response.error
+    it 'should have a error method', ->
+      response = new Response()
+      assert.equal typeof response.error, 'function'
 
-      'have a custom code and message after error': (response) ->
-        response.error('Error message', 123)
-        assert.equal response.error_message, 'Error message'
-        assert.equal response.error_code, 123
+    it 'should have a custom code and message after error', ->
+      response = new Response()
+      response.error('Error message', 123)
+      assert.equal response.error_message, 'Error message'
+      assert.equal response.error_code, 123
 
-      'have a custom code and null message after error': (response) ->
-        response.error('Error message')
-        assert.equal response.error_message, 'Error message'
-        assert.isNull response.error_code
+    it 'should have a custom code and null message after error', ->
+      response = new Response()
+      response.error('Error message')
+      assert.equal response.error_message, 'Error message'
+      assert.equal response.error_code, null
 
-      'have a is_success method': (response) ->
-        assert.isFunction response.is_success
+    it 'have a is_success method', ->
+      response = new Response()
+      assert.equal typeof response.is_success, 'function'
 
-      'be true after a call to success method': (response) ->
-        response.success()
-        assert.isTrue response.is_success()
+    it 'be true after a call to success method', ->
+      response = new Response()
+      response.success()
+      assert response.is_success()
 
-      'be false after a error method': (response) ->
-        response.error('Error message', 123)
-        assert.isFalse response.is_success()
-		
-  .export(module)
+    it 'be false after a error method', ->
+      response = new Response()
+      response.error('Error message', 123)
+      assert.equal response.is_success(), false
+

--- a/test/usage_report.coffee
+++ b/test/usage_report.coffee
@@ -1,0 +1,40 @@
+assert = require 'assert'
+nock   = require 'nock'
+
+# set keys as environment variables for tests that
+# run against the 3scale API or use dummy keys
+provider_key = process.env.TEST_3SCALE_PROVIDER_KEY
+application_key = process.env.TEST_3SCALE_APP_KEY
+application_id = process.env.TEST_3SCALE_APP_ID
+
+Client = require('../src/client')
+
+describe 'Usage report tests for 3Scale::Client', ->
+  it 'should successfully parse the response of the Authorize call', (done) ->
+    xml_body = "<status>\
+                  <authorized>false</authorized>\
+                  <reason>usage limits are exceeded</reason>\
+                  <plan>Ultimate</plan>\
+                  <usage_reports>\
+                    <usage_report metric=\"hits\" period=\"day\" exceeded=\"true\">\
+                      <period_start>2010-04-26 00:00:00 +0000</period_start>\
+                      <period_end>2010-04-27 00:00:00 +0000</period_end>\
+                      <current_value>50002</current_value>\
+                      <max_value>50000</max_value>\
+                    </usage_report>\
+                  </usage_reports>\
+                </status>"
+
+    nock('https://su1.3scale.net')
+      .get('/transactions/authorize.xml?app_id=foo&provider_key=1234abcd')
+      .reply(409, xml_body, { 'Content-Type': 'application/xml' })
+
+    client = new Client '1234abcd'
+    client.authorize { app_id: 'foo' }, (response) ->
+      assert.equal response.is_success(), false
+      assert.equal response.error_message, 'usage limits are exceeded'
+      assert.equal response.usage_reports[0].metric, 'hits'
+      assert.equal response.usage_reports[0].period, 'day'
+      assert.equal response.usage_reports[0].current_value, '50002'
+      assert.equal response.usage_reports[0].max_value, '50000'
+      done()

--- a/test/usage_report.coffee
+++ b/test/usage_report.coffee
@@ -35,6 +35,8 @@ describe 'Usage report tests for 3Scale::Client', ->
       assert.equal response.error_message, 'usage limits are exceeded'
       assert.equal response.usage_reports[0].metric, 'hits'
       assert.equal response.usage_reports[0].period, 'day'
+      assert.equal response.usage_reports[0].period_start, '2010-04-26 00:00:00 +0000'
+      assert.equal response.usage_reports[0].period_end, '2010-04-27 00:00:00 +0000'
       assert.equal response.usage_reports[0].current_value, '50002'
       assert.equal response.usage_reports[0].max_value, '50000'
       done()

--- a/test/usage_report_test.coffee
+++ b/test/usage_report_test.coffee
@@ -1,12 +1,6 @@
 assert = require 'assert'
 nock   = require 'nock'
 
-# set keys as environment variables for tests that
-# run against the 3scale API or use dummy keys
-provider_key = process.env.TEST_3SCALE_PROVIDER_KEY
-application_key = process.env.TEST_3SCALE_APP_KEY
-application_id = process.env.TEST_3SCALE_APP_ID
-
 Client = require('../src/client')
 
 describe 'Usage report tests for 3Scale::Client', ->


### PR DESCRIPTION
- add tests for the XML parsing done in authorize and authrep calls
- fix parsing of period_start and period_end
- add latest stable versions of Node.js (0.12, 4.x.x) to Travis tests
- rewrite tests in Mocha to make them simpler and more readable
