### PR TITLE
Fix issue with eternity periods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3scale",
   "description": "Client for 3Scale Networks API",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "homepage": "http://www.3scale.net",
   "repository": {
     "type": "git",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -350,10 +350,13 @@ module.exports = class Client
           report =
             period: usage_report.attr('period').value()
             metric: usage_report.attr('metric').value()
-            period_start: if @period isnt 'eternity' then usage_report.get('period_start').text()
-            period_end: if @period isnt 'eternity' then usage_report.get('period_end').text()
             current_value: usage_report.get('current_value').text()
             max_value: usage_report.get('max_value').text()
+
+          if report.period isnt 'eternity'
+            report.period_start = usage_report.get('period_start').text()
+            report.period_end = usage_report.get('period_end').text()
+
           response.add_usage_reports report
 
     response

--- a/test/usage_report_test.coffee
+++ b/test/usage_report_test.coffee
@@ -4,7 +4,7 @@ nock   = require 'nock'
 Client = require('../src/client')
 
 describe 'Usage report tests for 3Scale::Client', ->
-  it 'should successfully parse the response of the Authorize call', (done) ->
+  it 'should parse the response of the Authorize call', (done) ->
     xml_body = "<status>\
                   <authorized>false</authorized>\
                   <reason>usage limits are exceeded</reason>\
@@ -31,6 +31,35 @@ describe 'Usage report tests for 3Scale::Client', ->
       assert.equal response.usage_reports[0].period, 'day'
       assert.equal response.usage_reports[0].period_start, '2010-04-26 00:00:00 +0000'
       assert.equal response.usage_reports[0].period_end, '2010-04-27 00:00:00 +0000'
+      assert.equal response.usage_reports[0].current_value, '50002'
+      assert.equal response.usage_reports[0].max_value, '50000'
+      done()
+
+  it 'should parse the response of the Authorize call with eternity limits', (done) ->
+    xml_body = "<status>\
+                  <authorized>false</authorized>\
+                  <reason>usage limits are exceeded</reason>\
+                  <plan>Ultimate</plan>\
+                  <usage_reports>\
+                    <usage_report metric=\"hits\" period=\"eternity\" exceeded=\"true\">\
+                      <current_value>50002</current_value>\
+                      <max_value>50000</max_value>\
+                    </usage_report>\
+                  </usage_reports>\
+                </status>"
+
+    nock('https://su1.3scale.net')
+      .get('/transactions/authorize.xml?app_id=foo&provider_key=1234abcd')
+      .reply(409, xml_body, { 'Content-Type': 'application/xml' })
+
+    client = new Client '1234abcd'
+    client.authorize { app_id: 'foo' }, (response) ->
+      assert.equal response.is_success(), false
+      assert.equal response.error_message, 'usage limits are exceeded'
+      assert.equal response.usage_reports[0].metric, 'hits'
+      assert.equal response.usage_reports[0].period, 'eternity'
+      assert.equal response.usage_reports[0].period_start, undefined
+      assert.equal response.usage_reports[0].period_end, undefined
       assert.equal response.usage_reports[0].current_value, '50002'
       assert.equal response.usage_reports[0].max_value, '50000'
       done()


### PR DESCRIPTION
Using `@period` inside an object literal is undefined since `this` points to the global scope at that point.  
It was still working ok except for those cases where the `period_start` and `period_end` fields do not exist (which happens when period is "eternity"). 

Fixed and added test case.