### PR TITLE
Separate integration and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
 env:
   global:
     - CXX=g++-4.8
+    - TEST_3SCALE_APP_ID=4d4b20b9
+    - TEST_3SCALE_APP_KEY=ecce202ecc2eb8dc7a499c34a34d5987
+    - secure: B/3oWYZZttrXVM5IFn2evSuWMOQqEOOMol3nEQ2vEDGQ6rdGjpYLFDO/qMDPA8Af6Vt72lOFKkgzivuBp8nSd4S1YRTazilMle4zCJiJxzPs69kRDVXf/Mn8Qr/YrmgVzhblvdNqbKxTGrYyvDziPkliQKtIhqyILm3d6+CqmYw=
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ before_install:
 env:
   global:
     - CXX=g++-4.8
-    - TEST_3SCALE_APP_ID=4d4b20b9
-    - TEST_3SCALE_APP_KEY=ecce202ecc2eb8dc7a499c34a34d5987
-    - secure: B/3oWYZZttrXVM5IFn2evSuWMOQqEOOMol3nEQ2vEDGQ6rdGjpYLFDO/qMDPA8Af6Vt72lOFKkgzivuBp8nSd4S1YRTazilMle4zCJiJxzPs69kRDVXf/Mn8Qr/YrmgVzhblvdNqbKxTGrYyvDziPkliQKtIhqyILm3d6+CqmYw=
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "scripts": {
     "prepublish": "coffee --bare -o lib -c src",
-    "test": "mocha --compilers coffee:coffee-script/register test/*"
+    "test": "mocha --compilers coffee:coffee-script/register test/* -if 'Integration'",
+    "test-all": "mocha --compilers coffee:coffee-script/register test/*"
   },
   "directories": {
     "lib": "./lib"

--- a/test/client_test.coffee
+++ b/test/client_test.coffee
@@ -1,17 +1,11 @@
 assert = require 'assert'
 nock   = require 'nock'
 
-# set keys as environment variables for tests that
-# run against the 3scale API or use dummy keys
-provider_key = process.env.TEST_3SCALE_PROVIDER_KEY
-application_key = process.env.TEST_3SCALE_APP_KEY
-application_id = process.env.TEST_3SCALE_APP_ID
-
 trans = [
-  { 'app_id': application_id, 'usage': { 'hits': 1 } },
-  { 'app_id': application_id, 'usage': { 'hits': 1000 } }
+  { 'app_id': 'foo', 'usage': { 'hits': 1 } },
+  { 'app_id': 'foo', 'usage': { 'hits': 1000 } }
 ]
-report_test = {transactions: trans, provider_key: provider_key}
+report_test = {transactions: trans, provider_key: '1234abcd'}
 
 Client = require('../src/client')
 
@@ -30,64 +24,84 @@ describe 'Basic test for the 3Scale::Client', ->
       assert.equal client.host, 'example.com'
 
     it 'should have an authorize method', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.equal typeof client.authorize, 'function'
 
     it 'should throw an exception if authorize method is called without :app_id', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.throws (() -> client.authorize({}, () ->)), 'missing app_id'
 
     it 'should have an oauth_authorize method', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.equal typeof client.oauth_authorize, 'function'
 
     it 'should throw an exception if oauth_authorize method is called without :app_id', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.throws (() ->  client.oauth_authorize({}, () ->)), 'missing app_id'
 
     it 'should have an authorize_with_user_key method', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.equal typeof client.authorize_with_user_key, 'function'
 
     it 'should throw an exception if authorize_with_user_key is called without :user_key', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.throws (() -> client.authorize_with_user_key({}, () ->)), 'missing user_key'
 
     it 'should have an authrep method', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.equal typeof client.authrep, 'function'
 
     it 'should throw an exception if authrep called without :app_id', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.throws (() -> client.authrep({}, () ->)), 'missing app_id'
 
     it 'should have an authrep_with_user_key method', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.equal typeof client.authrep_with_user_key, 'function'
 
     it 'should throw an exception if authrep_with_user_key is called without :user_key', ->
-      client = new Client(provider_key)
+      client = new Client('1234abcd')
       assert.throws (() -> client.authrep_with_user_key({}, ()->)), 'missing user_key'
 
   describe 'The authorize method', ->
     it 'should call the callback with a successful response', (done) ->
-      client = new Client provider_key
-      client.authorize {app_key: application_key, app_id: application_id}, (response) ->
+      nock('https://su1.3scale.net')
+        .get('/transactions/authorize.xml')
+        .query({ app_key: 'bar', app_id: 'foo', provider_key: '1234abcd' })
+        .reply(200, '<status><authorized>true</authorized><plan>Basic</plan></status>')
+
+      client = new Client '1234abcd'
+      client.authorize {app_key: 'bar', app_id: 'foo'}, (response) ->
         assert response.is_success()
         done()
 
     it 'should call the callback with a error response if app_id was wrong', (done) ->
-      client = new Client provider_key
-      client.authorize {app_key: application_key, app_id: 'ERROR'}, (response) ->
+      nock('https://su1.3scale.net')
+        .get('/transactions/authorize.xml')
+        .query({ app_key: 'bar', app_id: 'ERROR', provider_key: '1234abcd' })
+        .reply(403, '<error code="application_not_found">application with id="ERROR" was not found</error>')
+
+      client = new Client '1234abcd'
+      client.authorize {app_key: 'bar', app_id: 'ERROR'}, (response) ->
         assert.equal response.is_success(), false
         done()
 
+    after ->
+      nock.cleanAll()
+
   describe 'The report method', ->
     it 'should give a success response with the correct params', (done) ->
-      client = new Client provider_key
+      nock('https://su1.3scale.net')
+        .post('/transactions.xml')
+        .reply(202)
+
+      client = new Client '1234abcd'
       client.report report_test, (response) ->
         assert response.is_success()
         done()
+
+    after ->
+      nock.cleanAll()
 
   describe 'Request headers in authrep calls', ->
     it 'should include the Host and X-3scale-User-Agent headers', (done) ->
@@ -105,6 +119,9 @@ describe 'Basic test for the 3Scale::Client', ->
         assert match.isDone()
         done()
 
+    after ->
+      nock.cleanAll()
+
   describe 'Request headers in report calls', ->
     it 'should include the Host and X-3scale-User-Agent headers', (done) ->
       opts =
@@ -120,3 +137,7 @@ describe 'Basic test for the 3Scale::Client', ->
       client.report report_test, (response) ->
         assert match.isDone()
         done()
+
+    after ->
+      nock.cleanAll()
+

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -1,0 +1,36 @@
+assert = require 'assert'
+
+# set keys as environment variables for tests that
+# run against the 3scale API or use dummy keys
+provider_key = process.env.TEST_3SCALE_PROVIDER_KEY
+application_key = process.env.TEST_3SCALE_APP_KEY
+application_id = process.env.TEST_3SCALE_APP_ID
+
+trans = [
+  { 'app_id': application_id, 'usage': { 'hits': 1 } },
+  { 'app_id': application_id, 'usage': { 'hits': 1000 } }
+]
+report_test = {transactions: trans, provider_key: provider_key}
+
+Client = require('../src/client')
+
+describe 'Integration tests for the 3Scale::Client', ->
+  describe 'The authorize method', ->
+    it 'should call the callback with a successful response', (done) ->
+      client = new Client provider_key
+      client.authorize {app_key: application_key, app_id: application_id}, (response) ->
+        assert response.is_success()
+        done()
+
+    it 'should call the callback with a error response if app_id was wrong', (done) ->
+      client = new Client provider_key
+      client.authorize {app_key: application_key, app_id: 'ERROR'}, (response) ->
+        assert.equal response.is_success(), false
+        done()
+
+  describe 'The report method', ->
+    it 'should give a success response with the correct params', (done) ->
+      client = new Client provider_key
+      client.report report_test, (response) ->
+        assert response.is_success()
+        done()


### PR DESCRIPTION
Now `npm test` only runs unit tests. The main benefit of this is that people external to 3scale will be able to submit PRs that pass the tests in Travis, since no encrypted keys will be needed.

To run all tests (including integration) use `npm run test-all`.
