### PR TITLE
Pass status code back to the caller

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -320,9 +320,9 @@ module.exports = class Client
 
       response.on 'end', () ->
         if response.statusCode == 202
-          response = new Response()
-          response.success()
-          callback response
+          _response = new Response()
+          _response.success(response.statusCode)
+          callback _response
         else if response.statusCode == 403
           callback _self._build_error_response(response.statusCode, xml)
     request.write query

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -71,9 +71,9 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback _self._build_success_authorize_response(response.statusCode, xml)
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
         else
           throw "[Client::authorize] Server Error Code: #{response.statusCode}"
     request.end()
@@ -119,9 +119,9 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback _self._build_success_authorize_response(response.statusCode, xml)
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
         else
           throw "[Client::oauth_authorize] Server Error Code: #{response.statusCode}"
     request.end()
@@ -168,9 +168,9 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback _self._build_success_authorize_response(response.statusCode, xml)
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
         else
           throw "[Client::authorize_with_user_key] Server Error Code: #{response.statusCode}"
     request.end()
@@ -216,9 +216,9 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback _self._build_success_authorize_response(response.statusCode, xml)
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
         else
           throw "[Client::authrep] Server Error Code: #{response.statusCode}"
     request.end()
@@ -251,9 +251,9 @@ module.exports = class Client
 
       response.on 'end', ->
         if response.statusCode == 200 || response.statusCode == 409
-          callback _self._build_success_authorize_response xml
+          callback _self._build_success_authorize_response(response.statusCode, xml)
         else if response.statusCode in [400...409]
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
         else
           throw "[Client::authrep_with_user_key] Server Error Code: #{response.statusCode}"
     request.end()
@@ -324,23 +324,23 @@ module.exports = class Client
           response.success()
           callback response
         else if response.statusCode == 403
-          callback _self._build_error_response xml
+          callback _self._build_error_response(response.statusCode, xml)
     request.write query
     request.end()
 
 
-  # privates methods
-  _build_success_authorize_response: (xml) ->
+  # private methods
+  _build_success_authorize_response: (status_code, xml) ->
     response = new AuthorizeResponse()
     doc = libxml.parseXml xml
     authorize = doc.get('//authorized').text()
     plan = doc.get('//plan').text()
 
     if authorize is 'true'
-      response.success()
+      response.success(status_code)
     else
       reason = doc.get('//reason').text()
-      response.error(reason)
+      response.error(status_code, reason)
 
     usage_reports = doc.get '//usage_reports'
 
@@ -361,11 +361,10 @@ module.exports = class Client
 
     response
 
-  _build_error_response: (xml) ->
-    response = new AuthorizeResponse()
+  _build_error_response: (status_code, xml) ->
     doc = libxml.parseXml xml
     error = doc.get '/error'
 
     response = new Response()
-    response.error error.text(), error.attr('code').value()
+    response.error status_code, error.text(), error.attr('code').value()
     response

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -2,17 +2,20 @@ class Response
 	constructor:() ->
 		@error_message = null
 		@error_code = null
-	
-	success: () ->
+		@status_code = null
+
+	success: (status_code) ->
 		@error_code = null
 		@error_message = null
-	
-	error: (message, code = null) ->
+		@status_code = 200
+    
+	error: (status_code, message, code = null) ->
 		@error_code = code
 		@error_message = message
-	
+		@status_code = status_code
+
 	is_success: () ->
 		((@error_code == null) && (@error_message == null))
-	
+
 
 module.exports = exports = Response

--- a/src/response.coffee
+++ b/src/response.coffee
@@ -7,7 +7,7 @@ class Response
 	success: (status_code) ->
 		@error_code = null
 		@error_message = null
-		@status_code = 200
+		@status_code = status_code
     
 	error: (status_code, message, code = null) ->
 		@error_code = code

--- a/test/client_test.coffee
+++ b/test/client_test.coffee
@@ -73,6 +73,7 @@ describe 'Basic test for the 3Scale::Client', ->
       client = new Client '1234abcd'
       client.authorize {app_key: 'bar', app_id: 'foo'}, (response) ->
         assert response.is_success()
+        assert.equal response.status_code, 200
         done()
 
     it 'should call the callback with a error response if app_id was wrong', (done) ->
@@ -84,6 +85,7 @@ describe 'Basic test for the 3Scale::Client', ->
       client = new Client '1234abcd'
       client.authorize {app_key: 'bar', app_id: 'ERROR'}, (response) ->
         assert.equal response.is_success(), false
+        assert.equal response.status_code, 403
         done()
 
     after ->

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -20,12 +20,14 @@ describe 'Integration tests for the 3Scale::Client', ->
       client = new Client provider_key
       client.authorize {app_key: application_key, app_id: application_id}, (response) ->
         assert response.is_success()
+        assert.equal response.status_code, 200
         done()
 
     it 'should call the callback with a error response if app_id was wrong', (done) ->
       client = new Client provider_key
       client.authorize {app_key: application_key, app_id: 'ERROR'}, (response) ->
         assert.equal response.is_success(), false
+        assert.equal response.status_code, 404
         done()
 
   describe 'The report method', ->
@@ -33,4 +35,5 @@ describe 'Integration tests for the 3Scale::Client', ->
       client = new Client provider_key
       client.report report_test, (response) ->
         assert response.is_success()
+        assert.equal response.status_code, 200
         done()

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -35,5 +35,5 @@ describe 'Integration tests for the 3Scale::Client', ->
       client = new Client provider_key
       client.report report_test, (response) ->
         assert response.is_success()
-        assert.equal response.status_code, 200
+        assert.equal response.status_code, 202
         done()

--- a/test/response_test.coffee
+++ b/test/response_test.coffee
@@ -41,7 +41,7 @@ describe 'Basic test for the 3Scale::Response', ->
 
     it 'should have a status_code of 200 after a call to success method', ->
       response = new Response()
-      response.success()
+      response.success(200)
       assert.equal response.status_code, 200
 
     it 'be false after a error method', ->

--- a/test/response_test.coffee
+++ b/test/response_test.coffee
@@ -20,13 +20,13 @@ describe 'Basic test for the 3Scale::Response', ->
 
     it 'should have a custom code and message after error', ->
       response = new Response()
-      response.error('Error message', 123)
+      response.error(403, 'Error message', 'error_code')
       assert.equal response.error_message, 'Error message'
-      assert.equal response.error_code, 123
+      assert.equal response.error_code, 'error_code'
 
     it 'should have a custom code and null message after error', ->
       response = new Response()
-      response.error('Error message')
+      response.error(403, 'Error message')
       assert.equal response.error_message, 'Error message'
       assert.equal response.error_code, null
 
@@ -39,8 +39,23 @@ describe 'Basic test for the 3Scale::Response', ->
       response.success()
       assert response.is_success()
 
+    it 'should have a status_code of 200 after a call to success method', ->
+      response = new Response()
+      response.success()
+      assert.equal response.status_code, 200
+
     it 'be false after a error method', ->
       response = new Response()
-      response.error('Error message', 123)
+      response.error(403, 'Error message', 'error_code')
       assert.equal response.is_success(), false
+
+    it 'should have a field for the status code', ->
+      response = new Response()
+      response.error(
+        409,
+        'user key "badkey" is invalid',
+        'user_key_invalid'
+      )
+      assert.equal response.status_code, 409
+
 

--- a/test/usage_report_test.coffee
+++ b/test/usage_report_test.coffee
@@ -26,6 +26,7 @@ describe 'Usage report tests for 3Scale::Client', ->
     client = new Client '1234abcd'
     client.authorize { app_id: 'foo' }, (response) ->
       assert.equal response.is_success(), false
+      assert.equal response.status_code, 409
       assert.equal response.error_message, 'usage limits are exceeded'
       assert.equal response.usage_reports[0].metric, 'hits'
       assert.equal response.usage_reports[0].period, 'day'
@@ -55,6 +56,7 @@ describe 'Usage report tests for 3Scale::Client', ->
     client = new Client '1234abcd'
     client.authorize { app_id: 'foo' }, (response) ->
       assert.equal response.is_success(), false
+      assert.equal response.status_code, 409
       assert.equal response.error_message, 'usage limits are exceeded'
       assert.equal response.usage_reports[0].metric, 'hits'
       assert.equal response.usage_reports[0].period, 'eternity'


### PR DESCRIPTION
Make the HTTP status code of the calls to the 3scale backend available in the response callback.