### PR TITLE
Migrate to xml2js

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "libxmljs": "*",
-    "qs": "^5.2.0"
+    "qs": "^5.2.0",
+    "xml2js": "^0.4.16"
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lib": "./lib"
   },
   "dependencies": {
+    "es6-promise": "^3.1.2",
     "qs": "^5.2.0",
     "xml2js": "^0.4.16"
   },


### PR DESCRIPTION
Removing our dependency on libxmljs which was causing many issues when building its native dependencies on certain environments. 
This PR builds on top of https://github.com/3scale/3scale_ws_api_for_nodejs/pull/25 by @picsoung.

A couple of notes:
- xml2js is different to libxmljs in that it has an asynchronous API, so it requires some internal changes
  in the way the response is passed to the user's callback
- introduce es6-promise to make it (hopefully) more readable
