### PR TITLE
allow multiple usage_report entries

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -363,6 +363,9 @@ module.exports = class Client
       response.set_plan plan
       
       if usage_reports
+
+        usage_reports = if usage_reports.usage_report.length? then usage_reports.usage_report else [usage_reports.usage_report]
+
         for index, usage_report of usage_reports
           do (usage_report) ->
             report =

--- a/test/usage_report_test.coffee
+++ b/test/usage_report_test.coffee
@@ -98,3 +98,49 @@ describe 'Usage report tests for 3Scale::Client', ->
       assert.equal response.usage_reports[0].current_value, '50002'
       assert.equal response.usage_reports[0].max_value, '50000'
       done()
+
+  it 'should parse the response of the Authorize call with multiple usage_report entries', (done) ->
+    xml_body = "<status>\
+                  <authorized>true</authorized>\
+                  <plan>Ultimate</plan>\
+                  <usage_reports>\
+                    <usage_report metric=\"hits\" period=\"day\" exceeded=\"false\">\
+                      <period_start>2010-04-26 00:00:00 +0000</period_start>\
+                      <period_end>2010-04-27 00:00:00 +0000</period_end>\
+                      <current_value>10002</current_value>\
+                      <max_value>50000</max_value>\
+                    </usage_report>\
+                    <usage_report metric=\"misses\" period=\"day\" exceeded=\"false\">\
+                      <period_start>2010-04-26 00:00:00 +0000</period_start>\
+                      <period_end>2010-04-27 00:00:00 +0000</period_end>\
+                      <current_value>12</current_value>\
+                      <max_value>50000</max_value>\
+                    </usage_report>\
+                  </usage_reports>\
+                </status>"
+
+    nock('https://su1.3scale.net')
+    .get('/transactions/authorize.xml?app_id=foo&provider_key=1234abcd')
+    .reply(200, xml_body, { 'Content-Type': 'application/xml' })
+
+    client = new Client '1234abcd'
+    client.authorize { app_id: 'foo' }, (response) ->
+      assert.equal response.is_success(), true
+      assert.equal response.status_code, 200
+      assert.equal response.plan, 'Ultimate'
+      
+      assert.equal response.usage_reports[0].metric, 'hits'
+      assert.equal response.usage_reports[0].period, 'day'
+      assert.equal response.usage_reports[0].period_start, '2010-04-26 00:00:00 +0000'
+      assert.equal response.usage_reports[0].period_end, '2010-04-27 00:00:00 +0000'
+      assert.equal response.usage_reports[0].current_value, '10002'
+      assert.equal response.usage_reports[0].max_value, '50000'
+      
+      assert.equal response.usage_reports[1].metric, 'misses'
+      assert.equal response.usage_reports[1].period, 'day'
+      assert.equal response.usage_reports[1].period_start, '2010-04-26 00:00:00 +0000'
+      assert.equal response.usage_reports[1].period_end, '2010-04-27 00:00:00 +0000'
+      assert.equal response.usage_reports[1].current_value, '12'
+      assert.equal response.usage_reports[1].max_value, '50000'
+      
+      done()


### PR DESCRIPTION
`xml2js` parsing behaviour related

when only 1 `usage_report` child in the `usage_reports` xml, it is parsed as an object
when multiple `usage_report` children, it is parsed as an array